### PR TITLE
Replace ordered and unordered

### DIFF
--- a/pandas_categorical/utils.py
+++ b/pandas_categorical/utils.py
@@ -90,6 +90,11 @@ def cat_astype(
         if col not in already_cat:
             is_ordered = col in ordered_cols
             data[col] = data[col].astype(pd.CategoricalDtype(ordered=is_ordered))
+        else:
+            if col not in ordered_cols and data[col].cat.ordered:
+                data[col] = data[col].cat.as_unordered()
+            elif col in ordered_cols and not data[col].cat.ordered:
+                data[col] = data[col].cat.as_ordered()
         if (remove_unused_categories) and (
             data[col].dropna().unique().shape[0] != data[col].cat.categories.shape[0]
         ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandas-categorical"
-version = "1.0.1"
+version = "1.0.2"
 description = "A set of functions for working with categorical columns in pandas"
 authors = ["KonstantinLosev <loskost@ya.ru>"]
 license = "MIT"


### PR DESCRIPTION
Previously, it was not possible to change an ordered column to an unordered one (and vice versa) using the `cat_astype` function.