### PR TITLE
Pin ubuntu version for testing

### DIFF
--- a/.github/workflows/testing_package.yml
+++ b/.github/workflows/testing_package.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
python 3.7 is not available in newer version ubuntu-24.04